### PR TITLE
Fix undefined variable reference in regionSyndromeAlerts endpoint mapping

### DIFF
--- a/R/api_utilities.R
+++ b/R/api_utilities.R
@@ -263,7 +263,7 @@ get_essence_data <- function(url, start_date = NULL,
     "dataDetails/csv" = profile$get_api_data(url_new, fromCSV = TRUE, ...),
     "summaryData" = profile$get_api_data(url_new) %>%
       extract2("summaryData"),
-    "alerts/regionSyndromeAlerts" = myProfile$get_api_data(url_new) %>%
+    "alerts/regionSyndromeAlerts" = profile$get_api_data(url_new) %>%
       extract2("regionSyndromeAlerts"),
     "alerts/hospitalSyndromeAlerts" = profile$get_api_data(url_new) %>%
       extract2("hospitalSyndromeAlerts"),


### PR DESCRIPTION
In `R/api_utilities.R`, the `get_essence_data()` function's internal mapping for the `alerts/regionSyndromeAlerts` endpoint referenced `myProfile$get_api_data(url_new)` instead of `profile$get_api_data(url_new)`. Every other endpoint in this same mapping list correctly uses `profile`, the actual function parameter name. `myProfile` is only referenced elsewhere as the default value assigned to that parameter (`profile = myProfile`), not as a usable name inside the function body on its own.

This would throw an `"object 'myProfile' not found"` error any time a user called this endpoint, unless they happened to have an object literally named `myProfile` in their global environment.

Likely went unnoticed because `myProfile` matches the conventional variable name used in the package's own docs/vignettes, so anyone following that convention had this line silently resolve correctly by coincidence. Breaks for anyone naming their profile object something else, or passing a different object through the `profile` argument.

Fixed by replacing` myProfile` with `profile` to match the function signature and every other line in the mapping. One line changed, no behavior change intended beyond making this endpoint callable for all users.